### PR TITLE
got rid of warnings on Linux g++8

### DIFF
--- a/macro.pfmoi/inst/include/RNG.hpp
+++ b/macro.pfmoi/inst/include/RNG.hpp
@@ -18,20 +18,7 @@
 
 // movement needs to sample a categorical distribution
 // stupid simple inversion method (Devroye III.2)
-static int rcategorical(const arma::Row<double>& probs){
-  int x = 0;
-  if(probs.size() == 1){
-    return x;
-  }
-  double s = probs.at(0);
-  double u = R::runif(0.,1.);
-  while(u > s){
-    x += 1;
-    s += probs.at(x);
-  }
-  return x;
-};
-
+int rcategorical(const arma::Row<double>& probs);
 
 /* PDG requires a multivariate hypergeometric random number, which we adapt the algorithm from Agner Fog here (cite him!) */
 // citation: Fog, A. "Non-uniform random number generators." (2005).
@@ -39,29 +26,6 @@ static int rcategorical(const arma::Row<double>& probs){
 // source: number of "balls" in each "urn"
 // n: number of draws to take
 // k: number of "urns"
-static void rmhyper(int* destination, int const* source, int n, int k){
-  int sum, x, y;
-  size_t i;
-  if(n < 0 || k < 0){Rcpp::stop("Invalid parameters of distribution");}
-
-  // total number of "balls"
-  for(i = 0, sum = 0; i < k; i++){
-    y = source[i];
-    if(y < 0){Rcpp::stop("Cannot have a negative number of balls in an urn");}
-    sum += y;
-  }
-  if(n > sum){Rcpp::stop("Distribution undefined for n > sum");}
-
-  for(i=0; i<k-1; i++){
-    // generate ouput by calling rhyper k-1 times
-    y = source[i];
-    x = (int)R::rhyper((double)y,(double)sum-y,(double)n);
-    n -= x;
-    sum -= y;
-    destination[i] = x;
-  }
-  // get the last one
-  destination[i] = n;
-};
+void rmhyper(int* destination, int const* source, int n, int k);
 
 #endif

--- a/macro.pfmoi/src/Human-PfMOI.cpp
+++ b/macro.pfmoi/src/Human-PfMOI.cpp
@@ -263,7 +263,7 @@ void human::queue_bites(){
 
   if(nbite > 0){
     double tnow = tileP->get_tnow();
-    for(size_t i=0; i<nbite; i++){
+    for(int i=0; i<nbite; i++){
       addEvent2Q(e_pfmoi_bite(tnow,this));
     }
   }

--- a/macro.pfmoi/src/RNG.cpp
+++ b/macro.pfmoi/src/RNG.cpp
@@ -1,0 +1,43 @@
+#include "RNG.hpp"
+
+
+int rcategorical(const arma::Row<double>& probs){
+    int x = 0;
+    if(probs.size() == 1){
+        return x;
+    }
+    double s = probs.at(0);
+    double u = R::runif(0.,1.);
+    while(u > s){
+        x += 1;
+        s += probs.at(x);
+    }
+    return x;
+};
+
+
+void rmhyper(int* destination, int const* source, int n, int k){
+    int sum=0, x=0, y=0;
+
+    if(n < 0 || k < 0){Rcpp::stop("Invalid parameters of distribution");}
+
+    // total number of "balls"
+    for(int sum_idx = 0, sum = 0; sum_idx < k; ++sum_idx){
+        y = source[sum_idx];
+        if(y < 0){Rcpp::stop("Cannot have a negative number of balls in an urn");}
+        sum += y;
+    }
+    if(n > sum){Rcpp::stop("Distribution undefined for n > sum");}
+
+    int gen_idx = 0;
+    for(; gen_idx<k-1; ++gen_idx){
+        // generate output by calling rhyper k-1 times
+        y = source[gen_idx];
+        x = (int)R::rhyper((double)y,(double)sum-y,(double)n);
+        n -= x;
+        sum -= y;
+        destination[gen_idx] = x;
+    }
+    // get the last one
+    destination[gen_idx] = n;
+};

--- a/macro.pfmoi/src/Tile.cpp
+++ b/macro.pfmoi/src/Tile.cpp
@@ -56,7 +56,7 @@ tile::tile(
 
   /* set up logging */
   if(verbose){std::cout << "begin initializing logging streams" << std::endl;}
-  for(size_t i=0; i<log_streams.size(); i++){
+  for(int i=0; i<log_streams.size(); i++){
     Rcpp::List log = Rcpp::as<Rcpp::List>(log_streams[i]);
     loggerPtr->open(
       Rcpp::as<std::string>(log["outfile"]),
@@ -68,7 +68,7 @@ tile::tile(
   /* construct patches */
   if(verbose){std::cout << "begin constructing patches" << std::endl;}
   patches.reserve(patch_pars.size());
-  for(size_t i=0; i<patch_pars.size(); i++){
+  for(int i=0; i<patch_pars.size(); i++){
     Rcpp::List p_par = Rcpp::as<Rcpp::List>(patch_pars[i]);
     patches.emplace_back(std::make_unique<patch>(p_par,this));
   }
@@ -76,7 +76,7 @@ tile::tile(
   /* construct human population */
   if(verbose){std::cout << "begin constructing human population" << std::endl;}
   humans.reserve(human_pars.size());
-  for(size_t i=0; i<human_pars.size(); i++){
+  for(int i=0; i<human_pars.size(); i++){
     Rcpp::List h_par = Rcpp::as<Rcpp::List>(human_pars[i]);
     humans.emplace_back(std::make_unique<human>(
       Rcpp::as<int>(h_par["id"]),
@@ -98,7 +98,7 @@ tile::tile(
   /* initialize vaccinations */
   if(verbose){std::cout << "begin initializing vaccinations" << std::endl;}
   if(vaxx_events.size() > 0){
-    for(size_t i=0; i<vaxx_events.size(); i++){
+    for(int i=0; i<vaxx_events.size(); i++){
 
       /* this vaccination 'packet' */
       Rcpp::List vaxx = Rcpp::as<Rcpp::List>(vaxx_events[i]);


### PR DESCRIPTION
These are changes to deal with Linux compilation under g++-8 and Ubuntu's toolchain.

- Change size_t to int in cases where it's really an int.
- Move code from a header to a source file when it's not a template, for RNG.hpp.
- Change index name from `i` to something specific to each for-loop, because reuse of variable names is a source of faults.
