### PR TITLE
Feature/initialize rng

### DIFF
--- a/docs/project/technical.md
+++ b/docs/project/technical.md
@@ -107,3 +107,7 @@ Advice we found:
 
  * Fog mixes Mersenne Twister with WELL.
 
+In conclusion, our safest bet is to be able to switch random
+number generators. Because Mersenne Twister is in use for almost
+everything, we should be able to initialize it consistently
+through C++ and R for now.

--- a/docs/project/technical.md
+++ b/docs/project/technical.md
@@ -54,8 +54,7 @@ by L'Ecuyer.
     the whole state, not just the seeds. This way you can
     continue on a stream.
 
-
-Again, let's list options.
+We would like to use tools that exist. Let's list options we know.
 
  * *R builtin* - R provides random number generation that's
    exported to C libraries. It's fine quality, and we are using
@@ -65,18 +64,23 @@ Again, let's list options.
  * *Boost RNG* - This is a standard. The boost generators
    don't skip ahead the Mersenne Twister, which is a standard generator.
    Has an R package that installs it for C++ inclusion.
+   It will skip Mersenne twister using the fast method (milliseconds)
+   if you ask for something more than 10^8 of a skip.
+   It's called `discard_many` in the source code.
 
  * *PRAND* - Barash made this library that includes a lot
    of generators. It isn't commonly used, but it has MT19937,
    which is standard.
 
  * *GSL RNG* - Also a standard, has MT19937. Has an R package
-   that installs it, which makes things easier.
+   that installs it, which makes things easier. I don't see
+   the skip-ahead in here.
 
- * *Mersenne Twister skipahead* - There are libraries that provide
-   skipahead or streams for MT19937. These may be less trusted.
-   Need to research this. We should be able to use this
-   to synchronize R's RNG with the one that C++ gets.
+ * *Mersenne Twister skipahead* - We could use something separate
+   to do the skip-ahead. The original conference proceeding,
+   by Haramoto, Matsumoto, L'Ecuyer in 2008, has code, but it
+   doesn't compile with current libraries.
+   http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/JUMP/index.html
 
  * *SPRNG* - The parallel random number generation library.
    This works for parallel or serial. It's trusted. It might
@@ -85,4 +89,21 @@ Again, let's list options.
 
  * *Agner Fog's libraries* - high quality PRNG designed in C++
    with Monte Carlo simulation in mind; has an example of an R
-   package which exports the functionality to R. Mathematically trustworthy https://www.agner.org/random/
+   package which uses these RNGs to draw from an urn (hypergeometric
+   distribution). Mathematically trustworthy https://www.agner.org/random/
+
+ * *RNGStreams* - From 1999, for parallel streams. Has C++ library
+   and is part of R in `parallel::nextRNGStream(seed)`. Isn't Mersenne
+   Twister. http://statmath.wu.ac.at/software/RngStreams/
+
+ * *randtools package* - This R package offers some different
+   generators, including an MT19937 that uses a newer initialization.
+   This might be needed if you want R and C++ to match what numbers
+   they generate.
+   
+Advice we found:
+
+ * Vigna says Mersenne Twister is awful: https://arxiv.org/abs/1910.06437
+
+ * Fog mixes Mersenne Twister with WELL.
+

--- a/macro/R/RcppExports.R
+++ b/macro/R/RcppExports.R
@@ -17,3 +17,25 @@ movements_of_human <- function(movement_list, human) {
     .Call('_macro_movements_of_human', PACKAGE = 'macro', movement_list, human)
 }
 
+#' Generate Mersenne Twister seed states skipped ahead by powers of two.
+#'
+#' A Mersenne Twister random number generator can be skipped ahead
+#' by large numbers of random numbers. This function uses the Boost
+#' implementation of that algorithm to skip ahead its version of
+#' mt19937, not mt19937_64.
+#'
+#' @param seed A single number, without too many 0 bits, to
+#'        initialize the random number generator.
+#' @param skip_size_power_two The jump will be two raised to this
+#'        power. If it is 14 or greater, it will use the
+#'        special algorithm.
+#' @param skip_count How many times to skip forward. This is
+#'        the number of simultaneous streams you want to use.
+#' @return A matrix of size 624 by skip_count. Put the 624
+#'         into the Mersenne seed in order to initialize it.
+#'
+#' @export
+skip_mersenne_twister <- function(seed, skip_size_power_two, skip_count) {
+    .Call('_macro_skip_mersenne_twister', PACKAGE = 'macro', seed, skip_size_power_two, skip_count)
+}
+

--- a/macro/R/random.R
+++ b/macro/R/random.R
@@ -1,6 +1,15 @@
+#' Set the seed on the Mersenne Twister random generator.
+#'
+#' The input is a vector of 624 integers, used to initialize
+#' an exact state for MT19937. We assume it comes from
+#'
+#' copies <- skip_mersenne_twister(4789, 17, 100)
+#' this_run <- 1 # Out of 100 copies we run.
+#' set_mersenne_seed(copies[, this_run])
 set_mersenne_seed <- function(seed_vector) {
   RNGkind(kind="Mersenne-Twister")
   offset <- length(.Random.seed) - length(seed_vector)
   .Random.seed[(1 + offset):(offset + length(seed_vector))] <<-
     seed_vector
+  invisible(NULL)
 }

--- a/macro/R/random.R
+++ b/macro/R/random.R
@@ -1,0 +1,6 @@
+set_mersenne_seed <- function(seed_vector) {
+  RNGkind(kind="Mersenne-Twister")
+  offset <- length(.Random.seed) - length(seed_vector)
+  .Random.seed[(1 + offset):(offset + length(seed_vector))] <<-
+    seed_vector
+}

--- a/macro/src/Makevars
+++ b/macro/src/Makevars
@@ -22,4 +22,7 @@ MARKOV_FLOW_OBJS = \
 	markov_flow_wrap.o \
 	RcppExports.o
 
-OBJECTS = $(MARKOV_FLOW_OBJS)
+RANDOM_GENERATOR_OBJS = \
+	random.o
+
+OBJECTS = $(MARKOV_FLOW_OBJS) $(RANDOM_GENERATOR_OBJS)

--- a/macro/src/RcppExports.cpp
+++ b/macro/src/RcppExports.cpp
@@ -52,12 +52,26 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// skip_mersenne_twister
+IntegerMatrix skip_mersenne_twister(int seed, int skip_size_power_two, int skip_count);
+RcppExport SEXP _macro_skip_mersenne_twister(SEXP seedSEXP, SEXP skip_size_power_twoSEXP, SEXP skip_countSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< int >::type seed(seedSEXP);
+    Rcpp::traits::input_parameter< int >::type skip_size_power_two(skip_size_power_twoSEXP);
+    Rcpp::traits::input_parameter< int >::type skip_count(skip_countSEXP);
+    rcpp_result_gen = Rcpp::wrap(skip_mersenne_twister(seed, skip_size_power_two, skip_count));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_macro_movement_init", (DL_FUNC) &_macro_movement_init, 1},
     {"_macro_movement_step", (DL_FUNC) &_macro_movement_step, 2},
     {"_macro_convert_to_r_movement", (DL_FUNC) &_macro_convert_to_r_movement, 2},
     {"_macro_movements_of_human", (DL_FUNC) &_macro_movements_of_human, 2},
+    {"_macro_skip_mersenne_twister", (DL_FUNC) &_macro_skip_mersenne_twister, 3},
     {NULL, NULL, 0}
 };
 

--- a/macro/src/random.cpp
+++ b/macro/src/random.cpp
@@ -8,31 +8,58 @@
 
 using namespace boost;
 using namespace Rcpp;
-using namespace stl;
+using namespace std;
+
+const size_t MASK31 = (1 >> 31);
+
+int twos_complement(size_t val) {
+    return static_cast<int>(
+        -(val & MASK31) + (val & ~MASK31)
+    );
+}
 
 
+//' Generate Mersenne Twister seed states skipped ahead by powers of two.
+//'
+//' A Mersenne Twister random number generator can be skipped ahead
+//' by large numbers of random numbers. This function uses the Boost
+//' implementation of that algorithm to skip ahead its version of
+//' mt19937, not mt19937_64.
+//'
+//' @param seed A single number, without too many 0 bits, to
+//'        initialize the random number generator.
+//' @param skip_size_power_two The jump will be two raised to this
+//'        power. If it is 14 or greater, it will use the
+//'        special algorithm.
+//' @param skip_count How many times to skip forward. This is
+//'        the number of simultaneous streams you want to use.
+//' @return A matrix of size 624 by skip_count. Put the 624
+//'         into the Mersenne seed in order to initialize it.
+//'
+//' @export
 // [[Rcpp::export]]
-NumericMatrix
+IntegerMatrix
 skip_mersenne_twister(int seed, int skip_size_power_two, int skip_count) {
-    mt19937<size_t> generator(seed);
+    mt19937 generator(seed);
 
     vector<size_t> seed_buffer(generator.state_size);
-    NumericMatrix skipped_seeds(generator.state_size, skip_count);
-    for (size_t skip_idx=0; skip_idx < skip_count; ++skip_idx) {
+    IntegerMatrix skipped_seeds(generator.state_size, skip_count);
+    for (int skip_idx=0; skip_idx < skip_count; ++skip_idx) {
         if (skip_idx > 0) {
             generator.discard(1 << skip_size_power_two);
         } // else the first one doesn't need to be skipped.
 
-        // Because Boost RNGs don't tell you their internal state.
+        // Because Boost RNGs don't tell you their internal state,
+        // but they will print it.
         stringstream string_buffer;
-        generator >> string_buffer;
-        string_buffer.rewind();
-        for (size_t read_int=0; read_int < generator.state_size; ++read_int) {
+        string_buffer << generator;
+        string_buffer.seekg(0);
+        for (int read_int=0; read_int < generator.state_size; ++read_int) {
             string_buffer >> seed_buffer[read_int];
         }
 
-        for (size_t state_idx=0; state_idx < generator.state_size; ++state_idx) {
-            skipped_seeds(state_idx, skip_idx) = seed_buffer[state_idx];
+        for (int state_idx=0; state_idx < generator.state_size; ++state_idx) {
+            skipped_seeds(state_idx, skip_idx) = twos_complement(seed_buffer[state_idx]);
         }
     }
 

--- a/macro/src/random.cpp
+++ b/macro/src/random.cpp
@@ -1,0 +1,40 @@
+// [[Rcpp::depends(BH)]]
+
+#include <vector>
+#include <sstream>
+
+#include "boost/random/mersenne_twister.hpp"
+#include "Rcpp.h"
+
+using namespace boost;
+using namespace Rcpp;
+using namespace stl;
+
+
+// [[Rcpp::export]]
+NumericMatrix
+skip_mersenne_twister(int seed, int skip_size_power_two, int skip_count) {
+    mt19937<size_t> generator(seed);
+
+    vector<size_t> seed_buffer(generator.state_size);
+    NumericMatrix skipped_seeds(generator.state_size, skip_count);
+    for (size_t skip_idx=0; skip_idx < skip_count; ++skip_idx) {
+        if (skip_idx > 0) {
+            generator.discard(1 << skip_size_power_two);
+        } // else the first one doesn't need to be skipped.
+
+        // Because Boost RNGs don't tell you their internal state.
+        stringstream string_buffer;
+        generator >> string_buffer;
+        string_buffer.rewind();
+        for (size_t read_int=0; read_int < generator.state_size; ++read_int) {
+            string_buffer >> seed_buffer[read_int];
+        }
+
+        for (size_t state_idx=0; state_idx < generator.state_size; ++state_idx) {
+            skipped_seeds(state_idx, skip_idx) = seed_buffer[state_idx];
+        }
+    }
+
+    return skipped_seeds;
+}

--- a/macro/tests/testthat.R
+++ b/macro/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(macro)
+
+test_check("macro")

--- a/macro/tests/testthat/test-random.R
+++ b/macro/tests/testthat/test-random.R
@@ -1,0 +1,31 @@
+test_that("can make random seeds for Mersenne Twister", {
+  skip_count <- 5
+  mersenne_dimensions <- 624
+  seed_matrix <- skip_mersenne_twister(4789, 17, skip_count)
+  seed_dimensions <- dim(seed_matrix)
+  expect_equal(seed_dimensions[1], mersenne_dimensions)
+  expect_equal(seed_dimensions[2], skip_count)
+})
+
+
+# The generator uses unsigned integers for initialization,
+# but R represents them as signed integers. Ensure some
+# of the 624 integers are less than zero.
+test_that("random seeds are over 31 bits", {
+  seed_matrix <- skip_mersenne_twister(4789, 17, 10)
+  expect_gt(31, log(max(abs(seed_matrix)), 2))
+})
+
+
+test_that("can use random seeds to set .Random.seed", {
+  seed_matrix <- skip_mersenne_twister(4789, 17, 2)
+  set.seed(23234)
+  set_mersenne_seed(seed_matrix[, 1])
+  a <- runif(10)
+  set_mersenne_seed(seed_matrix[, 2])
+  b <- runif(10)
+  expect_equal(0, sum(a == b))
+  set_mersenne_seed(seed_matrix[, 1])
+  c <- runif(10)
+  expect_equal(a, c)
+})


### PR DESCRIPTION
I read about Random Number Generators from everything we compiled, and there isn't a right answer for parallel, good random numbers. Agner Fog comes close.  I'd feel safest if I could switch RNGs in order to check that results don't change. This PR makes it possible to use the Mersenne Twister MT19937 from both R and C++, where you skip it ahead, for instance 10^17 random numbers. That should be an OK start.

It uses the Boost library's implementation of Mersenne Twister skipahead. The idea is to

1. Call the C++ Boost initialization in order to generate parameters for 1000 streams (or however many you need).
2. Store them somewhere, maybe a file.
3. Each parallel runner reads stream(s) and uses it to initialize its R and C++ generators.
