### PR TITLE
Feature/mosquito returns myza

### DIFF
--- a/macro/R/location_simpletrip.R
+++ b/macro/R/location_simpletrip.R
@@ -96,7 +96,11 @@ simple_trip_observer <- function(transition_name, former_state, new_state, curti
 #'    * \code{home}: vector of everybody's home
 #'    * \code{current}: vector of everybody's current location
 #'
-#' @param parameters A list or environment
+#' @param parameters A list or environment. If you make an environment with
+#'     `as.environment` then you may get an error "could not find function".
+#'     That's because the environment inherits from the empty environment.
+#'     Instead, use `list2env` to create the environment and it will, by
+#'     default, inherit from the parent frame.
 #'
 #' @return A simulation object, which is a list.
 #' @export
@@ -108,7 +112,7 @@ simple_trip_module <- function(parameters) {
 
   # parameter checking
   stopifnot(all(diag(parameters$trip_dest) == 0))
-  stopifnot(all(rowSums(parameters$trip_dest) == 1))
+  stopifnot(all(abs(rowSums(parameters$trip_dest) - 1) < 1e-15))
   stopifnot(nrow(parameters$trip_dest)==parameters$npatch & ncol(parameters$trip_dest)==parameters$npatch)
 
   stopifnot(nrow(parameters$return_home_rate)==parameters$npatch & ncol(parameters$return_home_rate)==parameters$npatch)

--- a/macro/tests/testthat/test-mosquito_rm.R
+++ b/macro/tests/testthat/test-mosquito_rm.R
@@ -1,3 +1,5 @@
+library(data.table)
+
 test_that("look_back_eip is right for small problem", {
   ll <- look_back_eip(c(3,3,2,2,2))
   compare <- list(c(2), c(2), numeric(0), c(3), c(3, 2))

--- a/macro/vignettes/hook_together.Rmd
+++ b/macro/vignettes/hook_together.Rmd
@@ -78,3 +78,54 @@ mash_step(health, bites)
 trajectory <- human_disease_path(health)
 ```
 
+# Mosquito Module
+
+```{r make_mosquito_module}
+year_days <- 365
+mosquito_parameters <- list(
+  duration = parameters$duration_days,
+  N = parameters$location_cnt,
+  lambda = matrix(rep(0.1, year_days * parameters$location_cnt), nrow = parameters$location_cnt),
+    psi = diag(parameters$location_cnt),  # diffusion matrix
+    EIP = rep(12, year_days),  # Extrinsic incubation period,
+    maxEIP = 12,  # Maximum length of EIP.
+    p = 0.9,  # survival
+    # human blood feeding rate, the proportion of mosquitoes that feed on humans each day
+    a = 0.6,
+    year_day_start = 1,
+    # Does not affect calculation value.
+    adult_scale = NULL  # Scale for mosquito population.
+  )
+module <- mosquito_rm_module(mosquito_parameters)
+bloodmeal_dt <- data.table(expand.grid(1:parameters$location_cnt, 1:parameters$duration_days))
+names(bloodmeal_dt) <- c("Location", "Time")
+bloodmeal_dt$Time <- bloodmeal_dt$Time - 1
+bloodmeal_dt$Bites <- sample(10:20, nrow(bloodmeal_dt), replace = TRUE)
+module <- mash_step(module, bloodmeal_dt)
+bites_dt <- mosquito_path(module)
+bites_dt
+```
+
+# Bloodmeal module
+
+```{r make_bloodmeal}
+params <- list(
+  human_cnt = 8L,
+  location_cnt = 5L,
+  duration = 10,
+  day_duration = 1,
+  dispersion = 1.5,
+  day_cnt = 10
+)
+health_dt <- sample_health_infection_status(params$human_cnt, params$duration)
+bite_weight <- runif(params$human_cnt, 0.2, 0.8)
+movement_dt <- sample_move_location(params$human_cnt, params$location_cnt, params$duration)
+mosquito_dt <- sample_mosquito_myz(params$location_cnt, params$duration)
+
+bloodmeal <- bloodmeal_density_module(params)
+bloodmeal <- mash_step(bloodmeal, health_dt, movement_dt, mosquito_dt)
+human_infections <- infects_human_path(bloodmeal)
+mosquito_infections <- infects_mosquito_path(bloodmeal)
+mosquito_infections
+```
+

--- a/macro/vignettes/hook_together.Rmd
+++ b/macro/vignettes/hook_together.Rmd
@@ -1,0 +1,55 @@
+---
+title: "Hook Some Things Together"
+output: html_notebook
+---
+
+```{r load_libs, show = FALSE}
+library(macro)
+library(data.table)
+```
+
+
+# Introduction
+
+We have some components that should form a malaria simulation. Let's walk through creating them and hooking them together.
+
+There are four parts: a human health module, a human movement module, a mosquito module, and a bloodmeal module. Each needs to be created to describe a set of locations with humans and mosquitoes. We can start with a general notion, for instance that there are three locations with 40 humans among them.
+```{r initial_sense}
+parameters <- list(
+  human_cnt = 40L,
+  location_cnt = 3L,
+  duration_days = 10
+)
+parameters$humans.l <- c(rmultinom(1, parameters$human_cnt, c(0.1, 0.3, 0.6)))
+```
+Here, the `.l` means it's a vector over locations. We'll use `.h` to mean a vector over humans. It's a convenient signal about what a variable's dimensions are for.
+
+# Movement Module
+
+This module is independent of the others, so let's take care of it first. It needs a stochastic matrix for movement, where rows are people and columns are locations.
+
+```{r make_simpletrip}
+start_at_home <- rep(1:parameters$location_cnt, parameters$humans.l)
+stopifnot(length(start_at_home) == parameters$human_cnt)
+
+stochastic_matrix <- matrix(runif(parameters$location_cnt^2), nrow = parameters$location_cnt)
+diag(stochastic_matrix) <- 0
+# The rows should sum to one.
+stochastic_matrix <- diag(1 / rowSums(stochastic_matrix)) %*% stochastic_matrix
+return_matrix <- matrix(1, nrow = parameters$location_cnt, ncol = parameters$location_cnt)
+diag(return_matrix) <- 0
+return_matrix <- diag(1 / rowSums(return_matrix)) %*% return_matrix
+
+simpletrip_parameters <- list2env(list(
+  trip_rate = rep(0.1, parameters$location_cnt),
+  trip_dest = stochastic_matrix,
+  return_home_rate = return_matrix,
+  npatch = parameters$location_cnt,
+  home = start_at_home,
+  current = start_at_home
+))
+movement <- simple_trip_module(simpletrip_parameters)
+movement <- mash_step(movement, parameters$duration_days, NULL)
+locations <- location_path(movement)
+```
+The resulting data structure is a list with an entry for each location. Each member is a data.table with three columns: `arrive`, `leave`, and `time`. The values in `arrive` or `leave` are the ID of the individual, where either one or the other is the ID, and the other one is `NaN`.

--- a/macro/vignettes/hook_together.Rmd
+++ b/macro/vignettes/hook_together.Rmd
@@ -24,6 +24,7 @@ parameters$humans.l <- c(rmultinom(1, parameters$human_cnt, c(0.1, 0.3, 0.6)))
 ```
 Here, the `.l` means it's a vector over locations. We'll use `.h` to mean a vector over humans. It's a convenient signal about what a variable's dimensions are for.
 
+
 # Movement Module
 
 This module is independent of the others, so let's take care of it first. It needs a stochastic matrix for movement, where rows are people and columns are locations.
@@ -53,3 +54,27 @@ movement <- mash_step(movement, parameters$duration_days, NULL)
 locations <- location_path(movement)
 ```
 The resulting data structure is a list with an entry for each location. Each member is a data.table with three columns: `arrive`, `leave`, and `time`. The values in `arrive` or `leave` are the ID of the individual, where either one or the other is the ID, and the other one is `NaN`.
+
+
+# Health Module
+
+The parameters for the health module are few.
+```{r make_health}
+health_parameters <- list(
+  recovery_rate = 1 / 200,
+  people_cnt = parameters$human_cnt,
+  duration_days = parameters$duration_days
+)
+health <- forced_si_module(health_parameters)
+current_time <- 0
+bites <- lapply(
+  1:parameters$human_cnt,
+  function(h_idx) {
+    times <- rexp(1, 0.1)
+    sort(times[times < 10])
+  }
+  )
+mash_step(health, bites)
+trajectory <- human_disease_path(health)
+```
+


### PR DESCRIPTION
This PR changes the return type of the Ross-Macdonald-style mosquito module to have columns for M, Y, Z, and a. Basically all state variables and the biting rate. This is the right format to pass into the bloodmeal.

I also started a vignette to hook everything together. I got to a point where it's clear they won't hook together and wanted to make a PR before modifying each module to have a consistent interface and outputs and inputs that work with each other. I should commit the working bits before venturing on a frenzy of integration work.