### PR TITLE
can plot across times

### DIFF
--- a/macro/vignettes/hook_only.Rmd
+++ b/macro/vignettes/hook_only.Rmd
@@ -117,35 +117,53 @@ modules = list(
   bloodmeal = bloodmeal,
   mosquito = mosquito_module
 )
+step_cnt <- 5
 observer <- complete_observer()
+singleobs <- vector(mode = "list", length = step_cnt)
+msgnames <- c(
+  "location", "bloodmeal_human", "bloodmeal_mosquito", "health", "mosquito")
 dump_if <- function(step, idx) { step == "bloodmeal" }
 seen <- list()
-for (main_idx in 1:10) {
+for (main_idx in 1:step_cnt) {
   cat(paste("Running 10-day step", main_idx, "\n"))
   modules <- step_mainloop(modules, observer, main_idx, dump_if)
-  observer <- modules$observer
+  singleobs[[main_idx]] <- lapply(
+    msgnames,
+    function(msgtype) {
+      data.table::rbindlist(modules$observer[[msgtype]])
+    }
+  )
+  names(singleobs[[main_idx]]) <- msgnames
 }
+observations <- lapply(
+  msgnames,
+  function(msgname) {
+    data.table::rbindlist(
+      lapply(singleobs, function(obs) obs[[msgname]])
+    )
+  }
+)
+names(observations) <- msgnames
 ```
 
+
 ```{r}
-day_idx <- 2
-day_str <- sprintf("%d", day_idx)
-bm <- observer$bloodmeal_mosquito[[day_str]]
+bm <- observations$bloodmeal_mosquito
 bm$Location <- as.factor(bm$Location)
 ggplot(bm, aes(Time, Bites, colour = Location)) + geom_point() +
   labs(title = "Bites in Each Location During Time Step", y = "Bites per Day")
 ```
+
 Bloodmeal's bites for the human.
 ```{r}
-bh <- observer$bloodmeal_human[[day_str]]
+bh <- observations$bloodmeal_human
 ggplot(bh, aes(times)) + geom_histogram(binwidth = 10 / 40) +
   labs(title = "Bites for all Humans During Time Step", y = "Bites per Quarter Day")
 ```
 
 
 ```{r}
-day_str <- "1"
-bmosy <- observer$mosquito[[day_str]]
+bmosy <- observations$mosquito
 bmosy1 <- bmosy[bmosy$Location == 1,]
 ymax <- 1.1 * max(bmosy1$M, bmosy1$Y, bmosy1$Z)
 plot(bmosy1$Time, bmosy1$M, type = "p", pch = 16,
@@ -154,3 +172,9 @@ points(bmosy1$Time, bmosy1$Y, col = "blue", pch = 16)
 points(bmosy1$Time, bmosy1$Z, col = "green", pch = 16)
 legend("bottomright", legend = c("M", "Y", "Z"), fill = c("black", "blue", "green"))
 ```
+```{r}
+library(ggplot2)
+mosy <- observations$mosquito[, c("Location", "Time", "M", "Y", "Z")]
+ggplot(data=mosy, aes(x=Time, y = Z)) + geom_point() + facet_wrap(~Location)
+```
+


### PR DESCRIPTION
This takes output from multiple time steps, aggregates it into data tables, and plots parts of it, for all of the time steps.
Found a bug where the output from one step had times that were within-step times.